### PR TITLE
Enabeling deployment of lerobot policies >= v3.0

### DIFF
--- a/crisp_gym/record/recording_manager.py
+++ b/crisp_gym/record/recording_manager.py
@@ -79,7 +79,7 @@ class RecordingManager(ABC):
             target=self._writer_proc,
             args=(),
             name="dataset_writer",
-            daemon=False,
+            daemon=_ADD_FRAME_HAS_TASK,  # For old lerobot versions < v3.0
         )
         self.writer.start()
 


### PR DESCRIPTION
Make it possible to deploy policies that were trained with a newer v3.0 version of lerobot. 