### PR TITLE
Fix a ROS topic typo

### DIFF
--- a/crisp_gym/teleop/teleop_sensor_stream.py
+++ b/crisp_gym/teleop/teleop_sensor_stream.py
@@ -40,7 +40,7 @@ class TeleopStreamedPose:
 
         self.node.create_subscription(
             Float32,
-            self._griper_topic,
+            self._gripper_topic,
             callback=self._callback_gripper,
             callback_group=ReentrantCallbackGroup(),
             qos_profile=qos_profile_sensor_data,


### PR DESCRIPTION
Hi @danielsanjosepro ,

Thanks for open sourcing this great repo! I found a ROS topic sub failure. The change is a typo fix and it is intuitive and safe.