### PR TITLE
feat!: require crisp_py 4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "ruff>=0.11.9",
     "gymnasium>=0.26.3,<2",
     "scipy>=1.15.2,<2",
-    "crisp_python>=3.0.0,<4",
+    "crisp_python>=4.0.0,<5",
     "rich>=14.0.0, <15",
 ]
 authors = [


### PR DESCRIPTION
Follow-up to learnsyslab/crisp_py#82, which migrates the shipped control configs to the vector-valued nullspace params from learnsyslab/crisp_controllers#69.

crisp_gym itself needs no code or config change: it has no references to `nullspace`/`stiffness`/`damping`/`max_tau` and ships no `config/control/`. It only names control configs, which resolve via `find_config()` to `files("crisp_py")/config` — so the crisp_py PR covers it.

Only the pin needs updating, otherwise crisp_gym stays on the old configs against a new controller.

**Blocked on crisp_py 4.0.0 being released.**

Note for users with site-local control YAMLs on `CRISP_CONFIG_PATH`: those need migrating by hand (scalar gains → arrays, drop `nullspace.weights.*`).